### PR TITLE
Merchant Business Intel Endpoint - Most Items

### DIFF
--- a/app/controllers/api/v1/merchants/most_items_controller.rb
+++ b/app/controllers/api/v1/merchants/most_items_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Merchants::MostItemsController < ApplicationController
+  def index
+    top_merchants_by_items_sold = Merchant.ranked_by_most_items_sold(params[:quantity])
+    render json: MerchantSerializer.new(top_merchants_by_items_sold)
+  end
+end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -12,4 +12,13 @@ class Merchant < ApplicationRecord
     .order("revenue DESC")
     .limit(limit)
   end
+
+  def self.ranked_by_most_items_sold(limit)
+      select("merchants.*, SUM(invoice_items.quantity) AS count_of_items_sold")
+      .joins(invoices: [:invoice_items, :transactions])
+      .where(transactions: {result: "success"})
+      .group(:id)
+      .order("count_of_items_sold DESC")
+      .limit(limit)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
         get "/:id/items", to: "items#index"
         get "/:id/invoices", to: "invoices#index"
         get "/most_revenue", to: "most_revenue#index"
+        get "/most_items", to: "most_items#index"
       end
 
       resources :merchants, only: [:index, :show]

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -39,5 +39,12 @@ RSpec.describe Merchant, type: :model do
         expect(Merchant.ranked_by_most_revenue(2)).to eq([@merchant_3, @merchant_1])
       end
     end
+
+    describe "#ranked_by_most_items_sold" do
+      it "returns the top x merchants ranked by total number of items sold" do
+        expect(Merchant.ranked_by_most_items_sold(1)).to eq([@merchant_3])
+        expect(Merchant.ranked_by_most_items_sold(2)).to eq([@merchant_3, @merchant_1])
+      end
+    end
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -243,6 +243,17 @@ RSpec.describe "Merchants API" do
         expect(top_merchants_by_revenue[0]["id"]).to eq(@merchant_3.id.to_s)
         expect(top_merchants_by_revenue[1]["id"]).to eq(@merchant_1.id.to_s)
       end
+
+      it "returns the top x merchants ranked by total number of items sold" do
+        get "/api/v1/merchants/most_items?quantity=2"
+
+        top_merchants_by_items_sold = JSON.parse(response.body)["data"]
+
+        expect(response).to be_successful
+        expect(top_merchants_by_items_sold.count).to eq(2)
+        expect(top_merchants_by_items_sold[0]["id"]).to eq(@merchant_3.id.to_s)
+        expect(top_merchants_by_items_sold[1]["id"]).to eq(@merchant_1.id.to_s)
+      end
     end
   end
 end


### PR DESCRIPTION
- Add test for Merchant Business Intel Endpoint - returns the top x merchants ranked by total number of items sold
- Add route for Merchant Business Intel Endpoint - returns the top x merchants ranked by total number of items sold
- Add test and class method 'ranked_by_most_items_sold' in Merchant model
- Add index method to Api::V1::Merchants::MostItemsController